### PR TITLE
Release v1.5.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -7,5 +7,14 @@ assignees: QU35T-code
 
 ---
 
-**Describe The Feature**
-Please present a concise description of the feature.
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,11 @@
+---
+name: Feature Request
+about: "For feature requests. Please search for existing issues first."
+title: "[FEAT] <title>"
+labels: feat
+assignees: QU35T-code
+
+---
+
+**Describe The Feature**
+Please present a concise description of the feature.

--- a/README.md
+++ b/README.md
@@ -280,6 +280,36 @@ VPN : EU_Release_Arena_1 downloaded successfully
 VPNs are located at the following path : /home/qu35t/.local/htb-cli
 ```
 
+The VPNs used can be listed with the `--list` flag
+
+```bash
+❯ htb-cli vpn --list
+
+Product: endgames
+No information available
+
+Product: labs
+ID: 201
+Friendly Name: EU Free 2
+Current Clients: 23
+Location: EU - Free
+
+Product: starting_point
+ID: 440
+Friendly Name: EU StartingPoint 2
+Current Clients: 104
+Location: EU - Starting Point
+
+Product: competitive
+ID: 201
+Friendly Name: EU Free 2
+Current Clients: 23
+Location: EU - Free
+
+Product: fortresses
+No information available
+```
+
 A VPN can be started with the `--start` flag
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -191,6 +191,15 @@ Global Flags:
   -v, --verbose        Verbose mode
 ```
 
+If no flag is submitted, htb-cli starts the machine in `release arena`.
+
+```bash
+❯ htb-cli start
+
+Machine spawned! Playing on the competitive server
+Target: 10.129.254.131
+```
+
 ```bash
 ❯ htb-cli start -m Visual
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@
 ## Completion
 
 ```bash
-❯ htb-cli completion zsh > ~/.local/htb-cli-completion
-❯ source ~/.local/htb-cli-completion
+❯ htb-cli completion zsh > ~/.local/htb-cli/completion
+❯ source ~/.local/htb-cli/completion
 ```
 
 ```bash

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Generates shell autocompletion file
 var completionCmd = &cobra.Command{
 	Use:       "completion [bash|zsh|fish|powershell]",
 	Short:     "Generate completion script",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,7 @@ var rootCmd = &cobra.Command{
 		}
 		config.GlobalConfig.Logger.Debug(fmt.Sprintf("Message : %s", message))
 		if strings.Contains(message, "A new update") {
-			fmt.Println(message)
+			fmt.Printf("%s\n\n", message)
 		}
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/GoToolSharing/htb-cli/config"
+	"github.com/GoToolSharing/htb-cli/lib/update"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
@@ -24,6 +26,15 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			config.GlobalConfig.Logger.Error("", zap.Error(err))
 			os.Exit(1)
+		}
+		message, err := update.Check(config.Version)
+		if err != nil {
+			config.GlobalConfig.Logger.Error("", zap.Error(err))
+			os.Exit(1)
+		}
+		config.GlobalConfig.Logger.Debug(fmt.Sprintf("Message : %s", message))
+		if strings.Contains(message, "A new update") {
+			fmt.Println(message)
 		}
 	},
 }

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -13,7 +13,7 @@ import (
 
 var submitCmd = &cobra.Command{
 	Use:   "submit",
-	Short: "Submit credentials (machines / challenges / arena)",
+	Short: "Submit credentials (machines / challenges / release arena)",
 	Long:  "This command allows for the submission of user and root flags discovered on vulnerable machines / challenges",
 	Run: func(cmd *cobra.Command, args []string) {
 		config.GlobalConfig.Logger.Info("Submit command executed")

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/GoToolSharing/htb-cli/config"
@@ -14,11 +15,12 @@ var updateCmd = &cobra.Command{
 	Short: "Check for updates",
 	Run: func(cmd *cobra.Command, args []string) {
 		config.GlobalConfig.Logger.Info("Update command executed")
-		err := update.Check(config.Version)
+		message, err := update.Check(config.Version)
 		if err != nil {
 			config.GlobalConfig.Logger.Error("", zap.Error(err))
 			os.Exit(1)
 		}
+		fmt.Println(message)
 
 		config.GlobalConfig.Logger.Info("Exit update command correctly")
 	},

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -11,9 +11,10 @@ import (
 	"go.uber.org/zap"
 )
 
+// Check if an update is available for htb-cli
 var updateCmd = &cobra.Command{
 	Use:   "update",
-	Short: "Check for updates",
+	Short: "Check if updates are available",
 	Run: func(cmd *cobra.Command, args []string) {
 		config.GlobalConfig.Logger.Info("Update command executed")
 		message, err := update.Check(config.Version)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/GoToolSharing/htb-cli/config"
 	"github.com/GoToolSharing/htb-cli/lib/update"
+	"github.com/GoToolSharing/htb-cli/lib/webhooks"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
@@ -21,6 +22,12 @@ var updateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		fmt.Println(message)
+
+		err = webhooks.SendToDiscord("update", message)
+		if err != nil {
+			config.GlobalConfig.Logger.Error("", zap.Error(err))
+			os.Exit(1)
+		}
 
 		config.GlobalConfig.Logger.Info("Exit update command correctly")
 	},

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -10,9 +10,10 @@ import (
 	"go.uber.org/zap"
 )
 
+// Displays the current version of htb-cli
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Displays the current version",
+	Short: "Displays the current version of htb-cli",
 	Run: func(cmd *cobra.Command, args []string) {
 		config.GlobalConfig.Logger.Info("Version command executed")
 		config.GlobalConfig.Logger.Debug(fmt.Sprintf("config.Version: %s", config.Version))

--- a/cmd/vpn.go
+++ b/cmd/vpn.go
@@ -107,11 +107,12 @@ var vpnCmd = &cobra.Command{
 				os.Exit(1)
 			}
 		} else if stopVPNParam {
-			_, err := vpn.Stop()
+			message, err := vpn.Stop()
 			if err != nil {
 				config.GlobalConfig.Logger.Error("", zap.Error(err))
 				os.Exit(1)
 			}
+			fmt.Println(message)
 		}
 		config.GlobalConfig.Logger.Info("Exit vpn command correctly")
 	},

--- a/cmd/vpn.go
+++ b/cmd/vpn.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/GoToolSharing/htb-cli/config"
 	"github.com/GoToolSharing/htb-cli/lib/vpn"
+	"github.com/GoToolSharing/htb-cli/lib/webhooks"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
@@ -20,6 +21,21 @@ var vpnCmd = &cobra.Command{
 			config.GlobalConfig.Logger.Error("", zap.Error(err))
 			os.Exit(1)
 		}
+		listVPNParam, err := cmd.Flags().GetBool("list")
+		if err != nil {
+			config.GlobalConfig.Logger.Error("", zap.Error(err))
+			os.Exit(1)
+		}
+
+		if listVPNParam {
+			err := vpn.List()
+			if err != nil {
+				config.GlobalConfig.Logger.Error("", zap.Error(err))
+				os.Exit(1)
+			}
+			return
+		}
+
 		startVPNParam, err := cmd.Flags().GetBool("start")
 		if err != nil {
 			config.GlobalConfig.Logger.Error("", zap.Error(err))
@@ -77,7 +93,7 @@ var vpnCmd = &cobra.Command{
 				pattern = "Release_Arena"
 				filename = config.BaseDirectory + "/*" + pattern + "*"
 			default:
-				fmt.Println("Available modes : labs - sp - fortresses - prolabs - endgames - competitive")
+				fmt.Println("Available modes (-m) : labs - sp - fortresses - prolabs - endgames - competitive")
 				return
 			}
 			// fmt.Println("FILENAME")
@@ -113,7 +129,13 @@ var vpnCmd = &cobra.Command{
 				os.Exit(1)
 			}
 			fmt.Println(message)
+			err = webhooks.SendToDiscord("vpn", message)
+			if err != nil {
+				config.GlobalConfig.Logger.Error("", zap.Error(err))
+				os.Exit(1)
+			}
 		}
+
 		config.GlobalConfig.Logger.Info("Exit vpn command correctly")
 	},
 }
@@ -121,7 +143,8 @@ var vpnCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(vpnCmd)
 	vpnCmd.Flags().BoolP("download", "d", false, "Download All VPNs from HackTheBox")
-	vpnCmd.Flags().BoolP("start", "", false, "Start VPN")
-	vpnCmd.Flags().BoolP("stop", "", false, "Stop VPN")
+	vpnCmd.Flags().BoolP("start", "", false, "Start a VPN")
+	vpnCmd.Flags().BoolP("stop", "", false, "Stop a VPN")
+	vpnCmd.Flags().BoolP("list", "", false, "List VPNs")
 	vpnCmd.Flags().StringP("mode", "m", "", "Mode")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -63,7 +63,7 @@ func ConfigureLogger() error {
 	var err error
 	GlobalConfig.Logger, err = cfg.Build()
 	if err != nil {
-		return fmt.Errorf("Logger configuration error: %v", err)
+		return fmt.Errorf("logger configuration error: %v", err)
 	}
 	zap.ReplaceGlobals(GlobalConfig.Logger)
 	return nil
@@ -88,7 +88,7 @@ func LoadConfig(filepath string) (map[string]string, error) {
 
 		parts := strings.SplitN(line, "=", 2)
 		if len(parts) != 2 {
-			return nil, fmt.Errorf("Incorrectly formatted line in configuration file: %s", line)
+			return nil, fmt.Errorf("incorrectly formatted line in configuration file: %s", line)
 		}
 
 		key := strings.TrimSpace(parts[0])
@@ -112,15 +112,15 @@ func validateConfig(key, value string) error {
 	switch key {
 	case "Logging", "Batch":
 		if value != "True" && value != "False" {
-			return fmt.Errorf("The value for '%s' must be 'True' or 'False', got : %s", key, value)
+			return fmt.Errorf("the value for '%s' must be 'True' or 'False', got : %s", key, value)
 		}
 	case "Proxy":
 		if value != "False" && !isValidHTTPorHTTPSURL(value) {
-			return fmt.Errorf("The URL for '%s' must be a valid URL starting with http or https, got : %s", key, value)
+			return fmt.Errorf("the URL for '%s' must be a valid URL starting with http or https, got : %s", key, value)
 		}
 	case "Discord":
 		if value != "False" && !isValidDiscordWebhook(value) {
-			return fmt.Errorf("The Discord webhook URL is invalid : %s", value)
+			return fmt.Errorf("the Discord webhook URL is invalid : %s", value)
 		}
 	}
 
@@ -145,7 +145,7 @@ func Init() error {
 		GlobalConfig.Logger.Info(fmt.Sprintf("The \"%s\" folder does not exist, creation in progress...\n", BaseDirectory))
 		err := os.MkdirAll(BaseDirectory, os.ModePerm)
 		if err != nil {
-			return fmt.Errorf("Error folder creation: %s", err)
+			return fmt.Errorf("error folder creation: %s", err)
 		}
 
 		GlobalConfig.Logger.Info(fmt.Sprintf("\"%s\" folder created successfully\n\n", BaseDirectory))
@@ -155,21 +155,22 @@ func Init() error {
 	if _, err := os.Stat(confFilePath); os.IsNotExist(err) {
 		file, err := os.Create(confFilePath)
 		if err != nil {
-			return fmt.Errorf("Error creating file: %v", err)
+			return fmt.Errorf("error creating file: %v", err)
 		}
 		defer file.Close()
 
-		configContent := `Discord = False`
+		configContent := `Discord = False
+		Update = False`
 
 		writer := bufio.NewWriter(file)
 		_, err = writer.WriteString(configContent)
 		if err != nil {
-			return fmt.Errorf("Error when writing to file: %v", err)
+			return fmt.Errorf("error when writing to file: %v", err)
 		}
 
 		err = writer.Flush()
 		if err != nil {
-			return fmt.Errorf("Error clearing buffer: %v", err)
+			return fmt.Errorf("error clearing buffer: %v", err)
 		}
 
 		GlobalConfig.Logger.Info("Configuration file created successfully.")
@@ -178,7 +179,7 @@ func Init() error {
 	GlobalConfig.Logger.Info("Loading configuration file...")
 	config, err := LoadConfig(BaseDirectory + "/default.conf")
 	if err != nil {
-		return fmt.Errorf("Error loading configuration file: %v", err)
+		return fmt.Errorf("error loading configuration file: %v", err)
 	}
 
 	GlobalConfig.Logger.Info("Configuration successfully loaded")

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ const BaseHackTheBoxAPIURL = "https://" + HostHackTheBox + "/api/v4"
 
 const StatusURL = "https://status.hackthebox.com/api/v2/status.json"
 
-const Version = "e5af44560704ff06973d3c8b12f036b9fc1dbd75"
+const Version = "ece0cda2365f65195470102e20a693fe8b22a3a5"
 
 func ConfigureLogger() error {
 	var logLevel zapcore.Level

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ const BaseHackTheBoxAPIURL = "https://" + HostHackTheBox + "/api/v4"
 
 const StatusURL = "https://status.hackthebox.com/api/v2/status.json"
 
-const Version = "982942e53ff495261b1222a60388a062251fbe7a"
+const Version = "7c58567788c9c9209e2021d70d24e0a9cccd4e98"
 
 func ConfigureLogger() error {
 	var logLevel zapcore.Level

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ const BaseHackTheBoxAPIURL = "https://" + HostHackTheBox + "/api/v4"
 
 const StatusURL = "https://status.hackthebox.com/api/v2/status.json"
 
-const Version = "7c58567788c9c9209e2021d70d24e0a9cccd4e98"
+const Version = "a2b2ab3549d7c7f207abf7faaf4a8b03cb860a5f"
 
 func ConfigureLogger() error {
 	var logLevel zapcore.Level

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ const BaseHackTheBoxAPIURL = "https://" + HostHackTheBox + "/api/v4"
 
 const StatusURL = "https://status.hackthebox.com/api/v2/status.json"
 
-const Version = "a2b2ab3549d7c7f207abf7faaf4a8b03cb860a5f"
+const Version = "919942ae0fa0ca5299af294ec7faab227c6035c7"
 
 func ConfigureLogger() error {
 	var logLevel zapcore.Level

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ const BaseHackTheBoxAPIURL = "https://" + HostHackTheBox + "/api/v4"
 
 const StatusURL = "https://status.hackthebox.com/api/v2/status.json"
 
-const Version = "919942ae0fa0ca5299af294ec7faab227c6035c7"
+const Version = "be56ffb07fe2d1c056ea2a8b4ed520a78e320dbd"
 
 func ConfigureLogger() error {
 	var logLevel zapcore.Level

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ const BaseHackTheBoxAPIURL = "https://" + HostHackTheBox + "/api/v4"
 
 const StatusURL = "https://status.hackthebox.com/api/v2/status.json"
 
-const Version = "ece0cda2365f65195470102e20a693fe8b22a3a5"
+const Version = "982942e53ff495261b1222a60388a062251fbe7a"
 
 func ConfigureLogger() error {
 	var logLevel zapcore.Level

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ const BaseHackTheBoxAPIURL = "https://" + HostHackTheBox + "/api/v4"
 
 const StatusURL = "https://status.hackthebox.com/api/v2/status.json"
 
-const Version = "4fdb0dc1c930b971ea27746ec295bdc3f6419e5f"
+const Version = "23bcd72d532ccff057f784afab567c4214e14037"
 
 func ConfigureLogger() error {
 	var logLevel zapcore.Level

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ const BaseHackTheBoxAPIURL = "https://" + HostHackTheBox + "/api/v4"
 
 const StatusURL = "https://status.hackthebox.com/api/v2/status.json"
 
-const Version = "be56ffb07fe2d1c056ea2a8b4ed520a78e320dbd"
+const Version = "cc08ff0d969bbc372d35ed6fb8569332cf513c67"
 
 func ConfigureLogger() error {
 	var logLevel zapcore.Level

--- a/lib/update/update.go
+++ b/lib/update/update.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/GoToolSharing/htb-cli/config"
 	"github.com/GoToolSharing/htb-cli/lib/utils"
-	"github.com/GoToolSharing/htb-cli/lib/webhooks"
 )
 
 func Check(newVersion string) (string, error) {
@@ -23,7 +22,7 @@ func Check(newVersion string) (string, error) {
 			return "", err
 		}
 		body, err := io.ReadAll(resp.Body)
-		config.GlobalConfig.Logger.Debug(fmt.Sprintf("Body: %s", utils.TruncateString(string(body), 2000)))
+		config.GlobalConfig.Logger.Debug(fmt.Sprintf("Body: %s", utils.TruncateString(string(body), 500)))
 		if err != nil {
 			return "", fmt.Errorf("error when reading the response: %v", err)
 		}
@@ -49,11 +48,6 @@ func Check(newVersion string) (string, error) {
 			message = fmt.Sprintf("You're up to date (dev) ! (%s)", commitHash)
 		}
 
-		err = webhooks.SendToDiscord("update", message)
-		if err != nil {
-			return "", err
-		}
-
 		return message, nil
 	}
 
@@ -77,11 +71,5 @@ func Check(newVersion string) (string, error) {
 		message = fmt.Sprintf("You're up to date ! (%s)", config.Version)
 	}
 
-	err = webhooks.SendToDiscord("update", message)
-	if err != nil {
-		return "", err
-	}
-
 	return message, nil
-
 }

--- a/lib/update/update.go
+++ b/lib/update/update.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/GoToolSharing/htb-cli/config"
 	"github.com/GoToolSharing/htb-cli/lib/utils"
@@ -23,6 +24,9 @@ func Check(newVersion string) (string, error) {
 		}
 		body, err := io.ReadAll(resp.Body)
 		config.GlobalConfig.Logger.Debug(fmt.Sprintf("Body: %s", utils.TruncateString(string(body), 500)))
+		if strings.Contains(string(body), "API rate limit") {
+			return "htb-cli cannot check for new updates at this time. Please try again later", nil
+		}
 		if err != nil {
 			return "", fmt.Errorf("error when reading the response: %v", err)
 		}

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -56,12 +56,12 @@ func GetHTBToken() (string, error) {
 	var htbToken = os.Getenv(envName)
 
 	if htbToken == "" {
-		return "", fmt.Errorf("Environment variable is not set : %v\n", envName)
+		return "", fmt.Errorf("environment variable is not set : %v\n", envName)
 	}
 
 	parts := strings.Split(htbToken, ".")
 	if len(parts) != 3 {
-		return "", fmt.Errorf("The %s variable must be an app token : https://app.hackthebox.com/profile/settings", envName)
+		return "", fmt.Errorf("the %s variable must be an app token : https://app.hackthebox.com/profile/settings", envName)
 	}
 
 	return htbToken, nil
@@ -124,7 +124,7 @@ func SearchItemIDByName(item string, element_type string) (string, error) {
 			}
 			os.Exit(0)
 		default:
-			return "", fmt.Errorf("No machine was found")
+			return "", fmt.Errorf("no machine was found")
 		}
 	} else if element_type == "Challenge" {
 		switch root.Challenges.(type) {
@@ -213,7 +213,7 @@ func SearchItemIDByName(item string, element_type string) (string, error) {
 			fmt.Println("No username found")
 		}
 	} else {
-		return "", errors.New("Bad element_type")
+		return "", errors.New("bad element_type")
 	}
 
 	// The HackTheBox API can return either a slice or a map
@@ -257,7 +257,7 @@ func GetMachineType(machine_id interface{}) (string, error) {
 	} else if info["retired"].(float64) == 1 {
 		return "retired", nil
 	}
-	return "", errors.New("Error: machine type not found")
+	return "", errors.New("error: machine type not found")
 }
 
 // GetUserSubscription returns the user's subscription level
@@ -498,4 +498,21 @@ func HTTPRequest(method string, urlParam string, jsonData []byte) (*http.Respons
 func GetCurrentUsername() string {
 	user, _ := user.Current()
 	return user.Username
+}
+
+func SearchLastReleaseArenaMachine() (string, error) {
+	url := fmt.Sprintf("%s/season/machine/active", config.BaseHackTheBoxAPIURL)
+	resp, err := HtbRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	info := ParseJsonMessage(resp, "data")
+	if info == nil {
+		return "", err
+	}
+	config.GlobalConfig.Logger.Debug(fmt.Sprintf("Information on the last active machine: %v", info))
+	machineF64 := info.(map[string]interface{})["id"].(float64)
+	machineID := int(machineF64)
+	machineIDstr := strconv.Itoa(machineID)
+	return machineIDstr, nil
 }

--- a/lib/vpn/models.go
+++ b/lib/vpn/models.go
@@ -1,8 +1,11 @@
 package vpn
 
 type Assigned struct {
-	ID           int    `json:"id"`
-	FriendlyName string `json:"friendly_name"`
+	ID               int    `json:"id"`
+	FriendlyName     string `json:"friendly_name"`
+	CurrentClients   int    `json:"current_clients"`
+	Location         string `json:"location"`
+	LocationFriendly string `json:"location_type_friendly"`
 }
 
 type Data struct {

--- a/lib/vpn/vpn.go
+++ b/lib/vpn/vpn.go
@@ -130,57 +130,6 @@ func DownloadAll() error {
 	return nil
 }
 
-// // Start starts the VPN connection using an OpenVPN configuration file.
-// func Start(configPath string) (string, error) {
-// 	fmt.Println("VPN is starting...")
-// 	cmd := "pgrep -fa openvpn"
-// 	processes, err := exec.Command("sh", "-c", cmd).Output()
-// 	if err != nil {
-// 		return "", fmt.Errorf("error retrieving OpenVPN processes : %v", err)
-// 	}
-
-// 	lines := strings.Split(string(processes), "\n")
-
-// 	uniquePaths := make(map[string]bool)
-
-// 	config.GlobalConfig.Logger.Debug(fmt.Sprintf("VPN processes: %v", lines))
-
-// 	for _, line := range lines {
-// 		if strings.TrimSpace(line) == "" {
-// 			continue
-// 		}
-
-// 		parts := strings.Fields(line)
-// 		configPath := parts[len(parts)-1]
-
-// 		if _, found := uniquePaths[configPath]; found {
-// 			continue
-// 		}
-
-// 		uniquePaths[configPath] = true
-
-// 		file, err := os.Open(configPath)
-// 		if err != nil {
-// 			return "", fmt.Errorf("error reading file %s: %v", configPath, err)
-// 		}
-// 		defer file.Close()
-
-// 		scanner := bufio.NewScanner(file)
-// 		for scanner.Scan() {
-// 			if strings.HasPrefix(scanner.Text(), "remote") && strings.Contains(scanner.Text(), "hackthebox.eu") {
-// 				config.GlobalConfig.Logger.Debug(fmt.Sprintf("HackTheBox VPN found : %s", configPath))
-// 				break
-// 			}
-// 		}
-
-// 		if err := scanner.Err(); err != nil {
-// 			return "", fmt.Errorf("error reading file %s: %v", configPath, err)
-// 		}
-// 	}
-
-// 	return "", nil
-// }
-
 // Start starts the VPN connection using an OpenVPN configuration file.
 func Start(configPath string) (string, error) {
 	config.GlobalConfig.Logger.Debug(fmt.Sprintf("VPN config file : %s", configPath))
@@ -318,25 +267,6 @@ func Status() (bool, error) {
 	}
 	return true, nil
 }
-
-// // Stop attempts to stop the currently active VPN connection.
-// func Stop() error {
-// 	fmt.Println("Try to stop the active VPN...")
-// 	pidFile := config.BaseDirectory + "/lab-vpn.pid"
-// 	pidData, err := os.ReadFile(pidFile)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	config.GlobalConfig.Logger.Debug(fmt.Sprintf("VPN PID : %v", pidData))
-
-// 	cmd := exec.Command("sudo", "kill", string(pidData))
-
-// 	err = cmd.Run()
-// 	if err != nil {
-// 		return err
-// 	}
-// 	return nil
-// }
 
 // Stop terminates any active HackTheBox OpenVPN connections.
 func Stop() (string, error) {

--- a/lib/vpn/vpn.go
+++ b/lib/vpn/vpn.go
@@ -316,6 +316,8 @@ func Stop() (string, error) {
 }
 
 func getVPNConfiguration(url string) error {
+	parts := strings.Split(url, "=")
+	productValue := parts[len(parts)-1]
 	resp, err := utils.HtbRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return err
@@ -323,6 +325,7 @@ func getVPNConfiguration(url string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == 401 {
+		fmt.Printf("Product: %s\nNo information available\n\n", productValue)
 		return nil
 	}
 
@@ -341,8 +344,6 @@ func getVPNConfiguration(url string) error {
 		return err
 	}
 
-	parts := strings.Split(url, "=")
-	productValue := parts[len(parts)-1]
 	fmt.Printf("Product: %s\nID: %d\nFriendly Name: %s\nCurrent Clients: %d\nLocation: %s\n\n", productValue, response.Data.Assigned.ID, response.Data.Assigned.FriendlyName, response.Data.Assigned.CurrentClients, response.Data.Assigned.LocationFriendly)
 	return nil
 }

--- a/lib/webhooks/webhooks.go
+++ b/lib/webhooks/webhooks.go
@@ -12,6 +12,9 @@ import (
 
 // SendToDiscord sends a message to a Discord channel using a webhook URL.
 func SendToDiscord(command string, message string) error {
+	if config.ConfigFile["Discord"] == "False" {
+		return nil
+	}
 	embed := Embed{
 		Title:       "htb-cli",
 		Description: fmt.Sprintf("User **%s** used the **%s** command.\n**Message:** %s", utils.GetCurrentUsername(), command, message),


### PR DESCRIPTION
* Adding `goroutines` to optimize time - #67
* Add an `update informer` that checks if a new version is available - #83 
* Add an `issue template` for `feature requests` - #84 
* Fix bug when `discord webhook` is not set - #87 
* If no flag is supplied to the `start` command, the machine in `release arena` is started - #88 
* New `--list` flag for VPN command to display VPNs in use.
* VPN command improved with new checks to avoid crashes.